### PR TITLE
Increased MAX_ARENAS from 64 to 256

### DIFF
--- a/code/game/bg_public.h
+++ b/code/game/bg_public.h
@@ -1463,7 +1463,7 @@ qboolean    BG_PlayerSeesItem( playerState_t *ps, entityState_t *item, int atTim
 void PM_ClipVelocity( vec3_t in, vec3_t normal, vec3_t out, float overbounce );
 
 #define ARENAS_PER_TIER     4
-#define MAX_ARENAS          64
+#define MAX_ARENAS          256
 #define MAX_ARENAS_TEXT     8192
 
 #define MAX_BOTS            64


### PR DESCRIPTION
Fixes "Max infos exceeded" message on opened callvote.
This allow add more custom maps to the maplist as well.